### PR TITLE
Reimplement note-del feature

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_NOTE_DISPLAYED_INDEX = "The note index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
@@ -1,0 +1,93 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.note.Note;
+import seedu.address.model.person.Person;
+
+/**
+ * Delete a note from a person in the address book
+ */
+public class DeleteNoteCommand extends Command {
+    public static final String COMMAND_WORD = "note-del";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Delete a note from the note-list of selected person from our contact list. "
+            + "Parameters: "
+            + "INDEX (must be a positive integer) "
+            + "NOTE-INDEX (must be a positive)\n"
+            + "Example: " + COMMAND_WORD + " "
+            + "1 "
+            + "2";
+
+    public static final String MESSAGE_NOT_IMPLEMENTED_YET =
+            "DeleteNote command not implemented yet";
+
+    public static final String MESSAGE_SUCCESS = "Note has been deleted: %1$s";
+
+    public static final String MESSAGE_ARGUMENTS = "Index: %1$d, Index: %2$d";
+
+    private final Index index;
+    private final Index noteIndex;
+
+    /**
+     * Constructor of DeleteNoteCommand class
+     * @param index index of the person in the filtered person list
+     * @param noteIndex index of the note from the person's note-list to be deleted
+     */
+    public DeleteNoteCommand(Index index, Index noteIndex) {
+        requireAllNonNull(index, noteIndex);
+        this.index = index;
+        this.noteIndex = noteIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToEdit = lastShownList.get(index.getZeroBased());
+        List<Note> newNotes = new ArrayList<>(personToEdit.getNotes());
+
+        if (noteIndex.getZeroBased() >= newNotes.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_NOTE_DISPLAYED_INDEX);
+        }
+        newNotes.remove(noteIndex.getZeroBased());
+
+        Person editedPerson = new Person(
+                personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
+                personToEdit.getAddress(), personToEdit.getTags(), newNotes);
+
+        model.setPerson(personToEdit, editedPerson);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        return new CommandResult(generateSuccessMessage(editedPerson));
+    }
+
+    /**
+     * Generates a command execution success message
+     * {@code personToEdit}.
+     */
+    private String generateSuccessMessage(Person personToEdit) {
+        return String.format(MESSAGE_SUCCESS, personToEdit);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || (other instanceof DeleteNoteCommand
+                && index.equals(((DeleteNoteCommand) other).index)
+                && noteIndex.equals(((DeleteNoteCommand) other).noteIndex));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -11,6 +11,7 @@ import seedu.address.logic.commands.AddNoteCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteNoteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
@@ -65,6 +66,9 @@ public class AddressBookParser {
 
         case AddNoteCommand.COMMAND_WORD:
             return new AddNoteCommandParser().parse(arguments);
+
+        case DeleteNoteCommand.COMMAND_WORD:
+            return new DeleteNoteCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/DeleteNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteNoteCommandParser.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteNoteCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new {@code DeleteNoteCommand} object
+ */
+public class DeleteNoteCommandParser implements Parser<DeleteNoteCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code DeleteNoteCommand}
+     * and returns a {@code DeleteNoteCommand} object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    @Override
+    public DeleteNoteCommand parse(String args) throws ParseException {
+        try {
+            String[] splitArgs = args.trim().split("\\s+", 2);
+            Index index = ParserUtil.parseIndex(splitArgs[0]);
+            Index noteIndex = ParserUtil.parseNoteIndex(splitArgs[1]);
+            return new DeleteNoteCommand(index, noteIndex);
+        } catch (ParseException | IndexOutOfBoundsException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteNoteCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -23,6 +23,8 @@ public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
 
+    public static final String MESSAGE_INVALID_NOTE_INDEX = "Note index is not a non-zero unsigned integer.";
+
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
@@ -34,6 +36,19 @@ public class ParserUtil {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
+    }
+
+    /**
+     * Parses {@code oneBasedNoteIndex} into an {@code NoteIndex} and returns it. Leading and trailing whitespaces
+     * will be trimmed.
+     * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
+     */
+    public static Index parseNoteIndex(String oneBasedNoteIndex) throws ParseException {
+        String trimmedNoteIndex = oneBasedNoteIndex.trim();
+        if (!StringUtil.isNonZeroUnsignedInteger(trimmedNoteIndex)) {
+            throw new ParseException(MESSAGE_INVALID_NOTE_INDEX);
+        }
+        return Index.fromOneBased(Integer.parseInt(trimmedNoteIndex));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/DeleteNoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteNoteCommandTest.java
@@ -1,0 +1,97 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.NOTE_FIRST_INDEX;
+import static seedu.address.testutil.TypicalIndexes.NOTE_SECOND_INDEX;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalTasks.getTypicalTaskBook;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.note.Note;
+import seedu.address.model.person.Person;
+
+/**
+ * Contains integration tests (interaction with the Model) for
+ * {@code DeleteNoteCommand}.
+ */
+public class DeleteNoteCommandTest {
+
+    private final Model model = new ModelManager(getTypicalAddressBook(), getTypicalTaskBook(), new UserPrefs());
+
+    @Test
+    public void constructor_nullIndex_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new DeleteNoteCommand(null, null));
+    }
+
+    @Test
+    public void execute_validNoteIndexUnfilteredList_success() throws Exception {
+        Person personToDeleteNoteFrom = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+        List<Note> newNotes = new ArrayList<>(personToDeleteNoteFrom.getNotes());
+        newNotes.remove(NOTE_FIRST_INDEX.getZeroBased());
+        Person personWithModifiedNote = new Person(personToDeleteNoteFrom.getName(), personToDeleteNoteFrom.getPhone(),
+                personToDeleteNoteFrom.getEmail(), personToDeleteNoteFrom.getAddress(),
+                personToDeleteNoteFrom.getTags(), newNotes);
+
+        DeleteNoteCommand deleteNoteCommand = new DeleteNoteCommand(INDEX_SECOND_PERSON, NOTE_FIRST_INDEX);
+
+        String expectedMessage = String.format(DeleteNoteCommand.MESSAGE_SUCCESS, personWithModifiedNote);
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(),
+                model.getTaskBook(), new UserPrefs());
+        deleteNoteCommand.execute(expectedModel);
+        assertCommandSuccess(deleteNoteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidNoteIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundNoteIndex = Index.fromOneBased(model.getFilteredPersonList().get(
+                INDEX_SECOND_PERSON.getZeroBased()).getNotes().size() + 1);
+        DeleteNoteCommand deleteNoteCommand = new DeleteNoteCommand(INDEX_SECOND_PERSON, outOfBoundNoteIndex);
+
+        assertCommandFailure(deleteNoteCommand, model, Messages.MESSAGE_INVALID_NOTE_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_invalidPersonIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundNoteIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        DeleteNoteCommand deleteNoteCommand = new DeleteNoteCommand(outOfBoundNoteIndex, NOTE_FIRST_INDEX);
+
+        assertCommandFailure(deleteNoteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        DeleteNoteCommand deleteNoteFirstCommand = new DeleteNoteCommand(INDEX_SECOND_PERSON, NOTE_FIRST_INDEX);
+        DeleteNoteCommand deleteNoteSecondCommand = new DeleteNoteCommand(INDEX_SECOND_PERSON, NOTE_SECOND_INDEX);
+
+        // same object -> returns true
+        assertTrue(deleteNoteFirstCommand.equals(deleteNoteFirstCommand));
+
+        // same values -> returns true
+        DeleteNoteCommand deleteNoteFirstCommandCopy = new DeleteNoteCommand(INDEX_SECOND_PERSON, NOTE_FIRST_INDEX);
+        assertTrue(deleteNoteFirstCommand.equals(deleteNoteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteNoteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteNoteFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(deleteNoteFirstCommand.equals(deleteNoteSecondCommand));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -6,6 +6,8 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.NOTE_FIRST_INDEX;
 
 import java.util.Arrays;
 import java.util.List;
@@ -15,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteNoteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
@@ -51,6 +54,14 @@ public class AddressBookParserTest {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
+    public void parseCommand_deleteNote() throws Exception {
+        DeleteNoteCommand command = (DeleteNoteCommand) parser.parseCommand(
+                DeleteNoteCommand.COMMAND_WORD + " " + INDEX_SECOND_PERSON.getOneBased()
+                        + " " + NOTE_FIRST_INDEX.getOneBased());
+        assertEquals(new DeleteNoteCommand(INDEX_SECOND_PERSON, NOTE_FIRST_INDEX), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteNoteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteNoteCommandParserTest.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.NOTE_FIRST_INDEX;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.DeleteNoteCommand;
+
+/**
+ * Contains tests for
+ * {@code DeleteNoteCommandParser}.
+ */
+public class DeleteNoteCommandParserTest {
+    private DeleteNoteCommandParser parser = new DeleteNoteCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteCommand() {
+        assertParseSuccess(parser, "2 1", new DeleteNoteCommand(INDEX_SECOND_PERSON, NOTE_FIRST_INDEX));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "2", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteNoteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_emptyArgs_throwsParseException() {
+        assertParseFailure(parser, "   ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteNoteCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -3,8 +3,10 @@ package seedu.address.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_NOTE_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.NOTE_FIRST_INDEX;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -55,6 +57,26 @@ public class ParserUtilTest {
 
         // Leading and trailing whitespaces
         assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("  1  "));
+    }
+
+    @Test
+    public void parseNoteIndex_invalidInput_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseNoteIndex("10 a"));
+    }
+
+    @Test
+    public void parseNoteIndex_outOfRangeInput_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_INVALID_NOTE_INDEX, ()
+            -> ParserUtil.parseNoteIndex(Long.toString(Integer.MAX_VALUE + 1)));
+    }
+
+    @Test
+    public void parseNoteIndex_validInput_success() throws Exception {
+        // No whitespaces
+        assertEquals(NOTE_FIRST_INDEX, ParserUtil.parseNoteIndex("1"));
+
+        // Leading and trailing whitespaces
+        assertEquals(NOTE_FIRST_INDEX, ParserUtil.parseIndex("  1  "));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -9,4 +9,6 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+    public static final Index NOTE_FIRST_INDEX = Index.fromOneBased(1);
+    public static final Index NOTE_SECOND_INDEX = Index.fromOneBased(2);
 }


### PR DESCRIPTION
1. Reimplements the `note-del` feature from #48  (previously reverted to fix validation checks)
2. Contains related test methods