### PR TITLE
AddTagCommand functionality update

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -12,5 +12,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_NOTE_DISPLAYED_INDEX = "The note index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_TASKS_LISTED_OVERVIEW = "%1$d tasks listed!";
+    public static final String MESSAGE_INVALID_TAG = "Tags must be alphanumeric only!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagCommand.java
@@ -82,7 +82,7 @@ public class AddTagCommand extends Command {
      * @param personToEdit Person to be edited
      * @return New Person object with the tag added (tag list updated)
      */
-    private Person addTagToPerson(Person personToEdit) {
+    private Person addTagToPerson(Person personToEdit) throws CommandException {
         // Keep all other fields the same
         Name updatedName = personToEdit.getName();
         Phone updatedPhone = personToEdit.getPhone();
@@ -95,7 +95,11 @@ public class AddTagCommand extends Command {
         // Changing tags
         // Make modifiable copy since Person#getTags returns an unmodifiable Set
         Set<Tag> tagList = new HashSet<>(personToEdit.getTags());
-        tagList.add(new Tag(this.tagName));
+        try {
+            tagList.add(new Tag(this.tagName));
+        } catch (Exception e) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TAG);
+        }
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, tagList,
                 updatedStrengths, updatedWeaknesses, updatedMisc);

--- a/src/main/java/seedu/address/logic/parser/AddTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddTagCommandParser.java
@@ -4,6 +4,9 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.sql.Array;
+import java.util.ArrayList;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.AddTagCommand;
@@ -20,18 +23,23 @@ public class AddTagCommandParser implements Parser {
      */
     public AddTagCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TAG);
 
-        // Get index with ParserUtil instead of ArgumentTokenizer methods
-        Index index;
-        try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (IllegalValueException ive) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTagCommand.MESSAGE_USAGE), ive);
-        }
+        // Tokenize all arguments
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, new Prefix(""));
 
-        // Get tag name with ArgumentTokenizer
-        String tagName = argMultimap.getValue(PREFIX_TAG).orElse("");
+        // Convert the argMultimap into an ArrayList<> for easier access
+        // The @ArgumentTokenizer produces a map with 3 elements:
+        // Element 1: Whitespace
+        // Element 2: Index
+        // Element 3: tagName string
+        ArrayList<String> values = new ArrayList<>(argMultimap.getAllValues(new Prefix("")));
+
+        // Get the index element in the ArrayList
+        int indexInt = Integer.parseInt(values.get(1));
+        Index index = Index.fromOneBased(indexInt); // Convert to fromOneBased index since contact list starts from 1
+
+        // Get the tagName element in the ArrayList
+        String tagName = values.get(2);
 
         return new AddTagCommand(index, tagName);
     }

--- a/src/main/java/seedu/address/logic/parser/AddTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddTagCommandParser.java
@@ -2,15 +2,13 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.sql.Array;
 import java.util.ArrayList;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.AddTagCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
 
 public class AddTagCommandParser implements Parser {
     /**
@@ -40,6 +38,12 @@ public class AddTagCommandParser implements Parser {
 
         // Get the tagName element in the ArrayList
         String tagName = values.get(2);
+        try {
+            new Tag(tagName);
+        } catch (Exception e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddTagCommand.MESSAGE_USAGE));
+        }
 
         return new AddTagCommand(index, tagName);
     }

--- a/src/test/java/seedu/address/logic/parser/AddTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddTagCommandParserTest.java
@@ -18,15 +18,13 @@ class AddTagCommandParserTest {
     @Test
     void parse_validArgs_returnsAddTagCommand() {
         AddTagCommand expectedAddTagCommand = new AddTagCommand(INDEX_FIRST_PERSON, TAG1);
-        assertParseSuccess(parser, "1 t/TAG1", expectedAddTagCommand);
-        // Messy user input with multiple whitespaces
-        assertParseSuccess(parser, " 1 t/  TAG1", expectedAddTagCommand);
+        assertParseSuccess(parser, " 1 TAG1", expectedAddTagCommand);
     }
 
     @Test
     void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser,
-                "asdkfasdfl",
+                " 1 t/friend",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTagCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
Previously, AddTagCommand accepted inputs like the following:

`tag-add-p 1 t/friend`

in order to add the tag `friend` to the first person (index 1) in the contact list.

**Updated functionality**

AddTagCommand no longer requires the tag qualifier `/t` in order to add tags.

`tag-add-p 1 friend` now does the same thing that `tag-add-p 1 t/friend` did previously.

**Upcoming:** 
Change DeleteTagCommand to not require `t/` as well.