### PR TITLE
DeleteTagCommand functionality update

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagCommand.java
@@ -97,6 +97,7 @@ public class AddTagCommand extends Command {
         Set<Tag> tagList = new HashSet<>(personToEdit.getTags());
         tagList.add(new Tag(this.tagName));
 
+
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, tagList,
                 updatedStrengths, updatedWeaknesses, updatedMisc);
     }

--- a/src/main/java/seedu/address/logic/parser/DeleteTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteTagCommandParser.java
@@ -2,12 +2,13 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.ArrayList;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.DeleteTagCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
 
 public class DeleteTagCommandParser implements Parser {
     /**
@@ -20,19 +21,29 @@ public class DeleteTagCommandParser implements Parser {
      */
     public DeleteTagCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TAG);
 
-        // Get index with ParserUtil instead of ArgumentTokenizer methods
-        Index index;
+        // Tokenize all arguments
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, new Prefix(""));
+
+        // Convert the argMultimap into an ArrayList<> for easier access
+        // The @ArgumentTokenizer produces a map with 3 elements:
+        // Element 1: Whitespace
+        // Element 2: Index
+        // Element 3: tagName string
+        ArrayList<String> values = new ArrayList<>(argMultimap.getAllValues(new Prefix("")));
+
+        // Get the index element in the ArrayList
+        int indexInt = Integer.parseInt(values.get(1));
+        Index index = Index.fromOneBased(indexInt); // Convert to fromOneBased index since contact list starts from 1
+
+        // Get the tagName element in the ArrayList
+        String tagName = values.get(2);
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (IllegalValueException ive) {
+            new Tag(tagName);
+        } catch (Exception e) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    DeleteTagCommand.MESSAGE_USAGE), ive);
+                    DeleteTagCommand.MESSAGE_USAGE));
         }
-
-        // Get tag name with ArgumentTokenizer
-        String tagName = argMultimap.getValue(PREFIX_TAG).orElse("");
 
         return new DeleteTagCommand(index, tagName);
     }

--- a/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
@@ -18,15 +18,13 @@ class DeleteTagCommandParserTest {
     @Test
     void parse_validArgs_returnsDeleteTagCommand() {
         DeleteTagCommand expectedDeleteTagCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, TAG1);
-        assertParseSuccess(parser, "1 t/friends", expectedDeleteTagCommand);
-        // Messy user input with multiple whitespaces
-        assertParseSuccess(parser, " 1 t/  friends", expectedDeleteTagCommand);
+        assertParseSuccess(parser, " 1 friends", expectedDeleteTagCommand);
     }
 
     @Test
     void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser,
-                "asdkfasdfl",
+                " 1 t/friend",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTagCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
Addendum to #104 

Previously, DeleteTagCommand accepted inputs like the following:

tag-del-p 1 t/friend

in order to delete the tag friend from the first person (index 1) in the contact list.

**Updated functionality**

DeleteTagCommand no longer requires the tag qualifier /t in order to delete tags.

tag-del-p 1 friend now does the same thing that tag-del-p 1 t/friend did previously.