### PR TITLE
Add tag to tasks command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddTagToTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagToTaskCommand.java
@@ -31,6 +31,7 @@ public class AddTagToTaskCommand extends Command {
             + "1 "
             + "important";
     public static final String MESSAGE_DUPLICATE_TAG_T = "This task already has this tag!";
+    public static final String MESSAGE_ADD_TAG_SUCCESS = "Added tag: %1$s";
 
     public final Index index;
     public final String tagName;

--- a/src/main/java/seedu/address/logic/commands/AddTagToTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagToTaskCommand.java
@@ -1,10 +1,28 @@
 package seedu.address.logic.commands;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 
 public class AddTagToTaskCommand extends Command {
+    public static final String COMMAND_WORD = "tag-add-t";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Add a tag to a task from our task list. "
+            + "Parameters: "
+            + "INDEX (must be a positive integer) "
+            + "TAG NAME (must be non-empty)\n"
+            + "Example: " + COMMAND_WORD + " "
+            + "1 "
+            + "important";
+
+    public final Index index;
+    public final String tagName;
+
+    public AddTagToTaskCommand(Index index, String tagName) {
+        this.index = index;
+        this.tagName = tagName;
+    }
     
     public CommandResult execute(Model model) throws CommandException {
         return null;

--- a/src/main/java/seedu/address/logic/commands/AddTagToTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagToTaskCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.commands.AddTagCommand.MESSAGE_ADD_TAG_SUCCESS;
-import static seedu.address.logic.commands.AddTagCommand.MESSAGE_DUPLICATE_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TASKS;
 
 import java.util.HashSet;
@@ -13,7 +12,6 @@ import java.util.Set;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.name.Name;
 import seedu.address.model.tag.Tag;
@@ -32,11 +30,16 @@ public class AddTagToTaskCommand extends Command {
             + "Example: " + COMMAND_WORD + " "
             + "1 "
             + "important";
-    public static final String MESSAGE_DUPlICATE_TAG_T = "This task already has this tag!";
+    public static final String MESSAGE_DUPLICATE_TAG_T = "This task already has this tag!";
 
     public final Index index;
     public final String tagName;
 
+    /**
+     * Public contructor for AddTagToTaskCommand
+     * @param index Index of target task
+     * @param tagName Tag to be added to the target task
+     */
     public AddTagToTaskCommand(Index index, String tagName) {
         requireAllNonNull(index, tagName);
 
@@ -44,6 +47,7 @@ public class AddTagToTaskCommand extends Command {
         this.tagName = tagName;
     }
 
+    @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Task> lastShownList = model.getFilteredTaskList();
@@ -58,7 +62,7 @@ public class AddTagToTaskCommand extends Command {
         // Exception when a duplicate tag is added
         Tag testTag = new Tag(this.tagName);
         if (taskToEdit.getTags().contains(testTag)) {
-            throw new CommandException(MESSAGE_DUPlICATE_TAG_T);
+            throw new CommandException(MESSAGE_DUPLICATE_TAG_T);
         }
 
         model.setTask(taskToEdit, editedTask);

--- a/src/main/java/seedu/address/logic/commands/AddTagToTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagToTaskCommand.java
@@ -1,0 +1,13 @@
+package seedu.address.logic.commands;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Model;
+
+public class AddTagToTaskCommand extends Command {
+    
+    public CommandResult execute(Model model) throws CommandException {
+        return null;
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/AddTagToTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagToTaskCommand.java
@@ -1,9 +1,21 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
+import seedu.address.model.name.Name;
+import seedu.address.model.task.Date;
+import seedu.address.model.task.EndTime;
+import seedu.address.model.task.StartTime;
+import seedu.address.model.task.Task;
 
 public class AddTagToTaskCommand extends Command {
     public static final String COMMAND_WORD = "tag-add-t";
@@ -20,12 +32,44 @@ public class AddTagToTaskCommand extends Command {
     public final String tagName;
 
     public AddTagToTaskCommand(Index index, String tagName) {
+        requireAllNonNull(index, tagName);
+
         this.index = index;
         this.tagName = tagName;
     }
     
     public CommandResult execute(Model model) throws CommandException {
-        return null;
+        requireNonNull(model);
+        List<Task> lastShownList = model.getFilteredTaskList();
+
+        // Exception when index out of bounds
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+
+            Task taskToEdit = lastShownList.get(index.getZeroBased());
+            Task editedTask;
+        }
+
     }
+
+    /**
+     * Creates and returns a {@code Task} with a new tag {@code tagName} added to
+     * {@code taskToEdit}
+     *
+     * @param taskToEdit Person to be edited
+     * @return New Task object with the tag added (tag list updated)
+     */
+    private Task addTaskToPerson(Task taskToEdit) throws CommandException {
+        // Keep all other fields the same
+        Name updatedName = taskToEdit.getName();
+        Date updatedDate = taskToEdit.getDate();
+        StartTime updatedStartTime = taskToEdit.getStartTime();
+        EndTime updatedEndTime = taskToEdit.getEndTime();
+        Set<Name> updatedPersons = taskToEdit.getPersons();
+
+
+
+    }
+
 
 }

--- a/src/main/java/seedu/address/logic/commands/AddTagToTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagToTaskCommandParser.java
@@ -1,15 +1,58 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.ArrayList;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new AddTaskCommand object
  */
 public class AddTagToTaskCommandParser implements Parser {
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code AddTagToTaskCommandParser}
+     * and returns a {@code AddTagToTaskCommand} object for execution
+     * * @param args Input string by user EXCEPT COMMAND WORD
+     *
+     * @return AddTagToTaskCommand object with arguments loaded in
+     * @throws ParseException If the user input does not conform to the expected format
+     */
 
     public AddTagToTaskCommand parse(String args) throws ParseException{
-        return null;
+        requireNonNull(args);
+
+        // Tokenize all arguments
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, new Prefix(""));
+
+        // Convert the argMultimap into an ArrayList<> for easier access
+        // The @ArgumentTokenizer produces a map with 3 elements:
+        // Element 1: Whitespace
+        // Element 2: Index
+        // Element 3: tagName string
+        ArrayList<String> values = new ArrayList<>(argMultimap.getAllValues(new Prefix("")));
+
+        // Get the index element in the ArrayList
+        int indexInt = Integer.parseInt(values.get(1));
+        Index index = Index.fromOneBased(indexInt); // Convert to fromOneBased index since contact list starts from 1
+
+        // Get the tagName element in the ArrayList
+        String tagName = values.get(2);
+        try {
+            new Tag(tagName);
+        } catch (Exception e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddTagToTaskCommand.MESSAGE_USAGE));
+        }
+
+        return new AddTagToTaskCommand(index, tagName);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/AddTagToTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagToTaskCommandParser.java
@@ -1,0 +1,15 @@
+package seedu.address.logic.commands;
+
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new AddTaskCommand object
+ */
+public class AddTagToTaskCommandParser implements Parser {
+
+    public AddTagToTaskCommand parse(String args) throws ParseException{
+        return null;
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddTagCommandParser.java
@@ -12,8 +12,8 @@ import seedu.address.model.tag.Tag;
 
 public class AddTagCommandParser implements Parser {
     /**
-     * Parses the given {@code String} of arguments in the context of the {@code DeleteTagCommand}
-     * and returns a {@code DeleteTagCommand} object for execution
+     * Parses the given {@code String} of arguments in the context of the {@code AddTagCommand}
+     * and returns a {@code AddTagCommand} object for execution
      * * @param args Input string by user EXCEPT COMMAND WORD
      *
      * @return DeleteTagCommand object with arguments loaded in

--- a/src/main/java/seedu/address/logic/parser/AddTagToTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddTagToTaskCommandParser.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.commands;
+package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
@@ -6,10 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import java.util.ArrayList;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.parser.ArgumentMultimap;
-import seedu.address.logic.parser.ArgumentTokenizer;
-import seedu.address.logic.parser.Parser;
-import seedu.address.logic.parser.Prefix;
+import seedu.address.logic.commands.AddTagToTaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 
@@ -26,7 +23,7 @@ public class AddTagToTaskCommandParser implements Parser {
      * @throws ParseException If the user input does not conform to the expected format
      */
 
-    public AddTagToTaskCommand parse(String args) throws ParseException{
+    public AddTagToTaskCommand parse(String args) throws ParseException {
         requireNonNull(args);
 
         // Tokenize all arguments

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -131,7 +131,7 @@ public class AddressBookParser {
 
         case LoadCourtCommand.COMMAND_WORD:
             return new LoadCourtCommandParser().parse(arguments);
-            
+
         case AddTagToTaskCommand.COMMAND_WORD:
             return new AddTagToTaskCommandParser().parse(arguments);
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -8,6 +8,8 @@ import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddTagCommand;
+import seedu.address.logic.commands.AddTagToTaskCommand;
+import seedu.address.logic.commands.AddTagToTaskCommandParser;
 import seedu.address.logic.commands.AddTaskCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.ClearTaskCommand;
@@ -129,6 +131,9 @@ public class AddressBookParser {
 
         case LoadCourtCommand.COMMAND_WORD:
             return new LoadCourtCommandParser().parse(arguments);
+            
+        case AddTagToTaskCommand.COMMAND_WORD:
+            return new AddTagToTaskCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -9,7 +9,6 @@ import java.util.regex.Pattern;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddTagCommand;
 import seedu.address.logic.commands.AddTagToTaskCommand;
-import seedu.address.logic.commands.AddTagToTaskCommandParser;
 import seedu.address.logic.commands.AddTaskCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.ClearTaskCommand;

--- a/src/test/data/JsonSerializableTaskBookTest/typicalTasksTaskBook.json
+++ b/src/test/data/JsonSerializableTaskBookTest/typicalTasksTaskBook.json
@@ -15,7 +15,7 @@
     "tagged" : [ "colleagues" ],
     "persons" : ["Carl Kurz"]
   }, {
-    "name" : "Shareholder Meeting",
+    "name" : "Shareholder Conference",
     "date" : "29-02-2020",
     "startTime" : "14:00",
     "endTime" : "16:00",

--- a/src/test/java/seedu/address/logic/commands/AddTagToTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTagToTaskCommandTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showTaskAtIndex;
+import static seedu.address.logic.commands.CommandTestUtil.showTaskAtName;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.TASK_FIRST_INDEX;
 import static seedu.address.testutil.TypicalIndexes.TASK_SECOND_INDEX;
@@ -68,7 +68,7 @@ class AddTagToTaskCommandTest {
 
     @Test
     public void execute_invalidTagIndexFilteredList_failure() {
-        showTaskAtIndex(model, TASK_FIRST_INDEX);
+        showTaskAtName(model, TASK_FIRST_INDEX);
         Index outOfBoundIndex = TASK_SECOND_INDEX;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getTaskBook().getTaskList().size());

--- a/src/test/java/seedu/address/logic/commands/AddTagToTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTagToTaskCommandTest.java
@@ -1,0 +1,85 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalTasks.getTypicalTaskBook;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.TaskBook;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
+import seedu.address.testutil.PersonBuilder;
+
+class AddTagToTaskCommandTest {
+    // Test tags
+    // Because PersonBuilder#withTags takes String ... instead of Set<Tag>
+    private static final String TAG1 = "TAG1";
+
+    // Test model
+    private Model model = new ModelManager(getTypicalAddressBook(), getTypicalTaskBook(), new UserPrefs());
+
+    @Test
+    void execute_addTagCommandUnfilteredList_success() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        // Adding 1 more tag to the editedPerson
+        Set<Tag> firstPersonTags = new HashSet<>(firstPerson.getTags()); // Copy of Set<Tag> of ALICE (first person)
+        firstPersonTags.add(new Tag(TAG1));
+
+        // Convert Set<Tag> to array for PersonBuilder#withTags
+        String[] firstPersonTagsStringArray = firstPersonTags
+                .stream()
+                .map(x -> x.tagName)
+                .toArray(String[]::new);
+
+        Person editedPerson = new PersonBuilder(firstPerson).withTags(firstPersonTagsStringArray).build();
+
+        AddTagCommand addTagCommand = new AddTagCommand(INDEX_FIRST_PERSON, TAG1);
+
+        String expectedMessage = String.format(AddTagCommand.MESSAGE_ADD_TAG_SUCCESS, TAG1);
+
+        Model expectedModel = new ModelManager(
+                new AddressBook(model.getAddressBook()),
+                new TaskBook(model.getTaskBook()),
+                new UserPrefs());
+        expectedModel.setPerson(firstPerson, editedPerson);
+
+        assertCommandSuccess(addTagCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidPersonIndexFilteredList_failure() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        AddTagCommand addTagCommand = new AddTagCommand(outOfBoundIndex, TAG1);
+
+        assertCommandFailure(addTagCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final AddTagCommand command = new AddTagCommand(INDEX_FIRST_PERSON, TAG1);
+
+        // If they are the same objects, they are equal
+        assertTrue(command.equals(command));
+
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/AddTagToTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTagToTaskCommandTest.java
@@ -3,10 +3,8 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.logic.commands.CommandTestUtil.showTaskAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalIndexes.TASK_FIRST_INDEX;
 import static seedu.address.testutil.TypicalIndexes.TASK_SECOND_INDEX;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -17,8 +15,6 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
-import com.sun.javafx.scene.control.MultipleAdditionAndRemovedChange;
-
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.model.AddressBook;
@@ -26,10 +22,8 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.TaskBook;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.task.Task;
-import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.TaskBuilder;
 
 class AddTagToTaskCommandTest {

--- a/src/test/java/seedu/address/logic/commands/AddTagToTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTagToTaskCommandTest.java
@@ -4,8 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.logic.commands.CommandTestUtil.showTaskAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.TASK_FIRST_INDEX;
+import static seedu.address.testutil.TypicalIndexes.TASK_SECOND_INDEX;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalTasks.getTypicalTaskBook;
 
@@ -13,6 +16,8 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
+
+import com.sun.javafx.scene.control.MultipleAdditionAndRemovedChange;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
@@ -23,7 +28,9 @@ import seedu.address.model.TaskBook;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.task.Task;
 import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.TaskBuilder;
 
 class AddTagToTaskCommandTest {
     // Test tags
@@ -35,48 +42,51 @@ class AddTagToTaskCommandTest {
 
     @Test
     void execute_addTagCommandUnfilteredList_success() {
-        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Task firstTask = model.getFilteredTaskList().get(TASK_FIRST_INDEX.getZeroBased());
 
-        // Adding 1 more tag to the editedPerson
-        Set<Tag> firstPersonTags = new HashSet<>(firstPerson.getTags()); // Copy of Set<Tag> of ALICE (first person)
-        firstPersonTags.add(new Tag(TAG1));
+        // Adding 1 more tag to the firstTask
+        Set<Tag> firstTaskTags = new HashSet<>(firstTask.getTags()); // Set<Tag> copy of Shareholders Meeting (1st task)
+        firstTaskTags.add(new Tag(TAG1));
 
-        // Convert Set<Tag> to array for PersonBuilder#withTags
-        String[] firstPersonTagsStringArray = firstPersonTags
+        // Convert Set<Tag> to array for TaskBuilder#withTags
+        String[] firstTaskTagsStringArray = firstTaskTags
                 .stream()
                 .map(x -> x.tagName)
                 .toArray(String[]::new);
 
-        Person editedPerson = new PersonBuilder(firstPerson).withTags(firstPersonTagsStringArray).build();
+        // Manually building the edited task
+        Task editedTask = new TaskBuilder(firstTask).withTags(firstTaskTagsStringArray).build();
 
-        AddTagCommand addTagCommand = new AddTagCommand(INDEX_FIRST_PERSON, TAG1);
+        AddTagToTaskCommand addTagToTaskCommand = new AddTagToTaskCommand(TASK_FIRST_INDEX, TAG1);
 
-        String expectedMessage = String.format(AddTagCommand.MESSAGE_ADD_TAG_SUCCESS, TAG1);
+        String expectedMessage = String.format(AddTagToTaskCommand.MESSAGE_ADD_TAG_SUCCESS, TAG1);
 
+        // Manually building the expected model
         Model expectedModel = new ModelManager(
                 new AddressBook(model.getAddressBook()),
                 new TaskBook(model.getTaskBook()),
                 new UserPrefs());
-        expectedModel.setPerson(firstPerson, editedPerson);
+        expectedModel.setTask(firstTask, editedTask);
 
-        assertCommandSuccess(addTagCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(addTagToTaskCommand, model, expectedMessage, expectedModel);
+
     }
 
     @Test
-    public void execute_invalidPersonIndexFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+    public void execute_invalidTagIndexFilteredList_failure() {
+        showTaskAtIndex(model, TASK_FIRST_INDEX);
+        Index outOfBoundIndex = TASK_SECOND_INDEX;
         // ensures that outOfBoundIndex is still in bounds of address book list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getTaskBook().getTaskList().size());
 
-        AddTagCommand addTagCommand = new AddTagCommand(outOfBoundIndex, TAG1);
+        AddTagToTaskCommand addTagToTaskCommand = new AddTagToTaskCommand(outOfBoundIndex, TAG1);
 
-        assertCommandFailure(addTagCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(addTagToTaskCommand, model, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        final AddTagCommand command = new AddTagCommand(INDEX_FIRST_PERSON, TAG1);
+        final AddTagToTaskCommand command = new AddTagToTaskCommand(INDEX_FIRST_PERSON, TAG1);
 
         // If they are the same objects, they are equal
         assertTrue(command.equals(command));

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -180,17 +180,17 @@ public class CommandTestUtil {
     }
 
     /**
-     * Updates {@code model}'s filtered list to show only the task at the given {@code targetIndex} in the
+     * Updates {@code model}'s filtered list to show only the tasks with the given {@code Name} in the
      * {@code model}'s task book.
      */
-    public static void showTaskAtIndex(Model model, Index targetIndex) {
+    public static void showTaskAtName(Model model, Index targetIndex) {
         assertTrue(targetIndex.getZeroBased() < model.getFilteredTaskList().size());
 
         Task task = model.getFilteredTaskList().get(targetIndex.getZeroBased());
         final String[] splitName = task.getName().fullName.split("\\s+");
         model.updateFilteredTaskList(new TaskNameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
-        assertEquals(1, model.getFilteredTaskList().size());
+        assertEquals(1, model.getFilteredTaskList().size()); // The task book contains only unique names
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/FindTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindTaskCommandTest.java
@@ -7,7 +7,6 @@ import static seedu.address.commons.core.Messages.MESSAGE_TASKS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalTasks.FIRST_TASK;
-import static seedu.address.testutil.TypicalTasks.THIRD_TASK;
 import static seedu.address.testutil.TypicalTasks.getTypicalTaskBook;
 
 import java.util.Arrays;
@@ -77,13 +76,13 @@ public class FindTaskCommandTest {
     public void execute_multipleKeywords_multiplePersonsAndTagsFound() {
         List<String> nameList = Arrays.asList("Meeting", "Dinner");
         List<String> tagList = Arrays.asList("friends", "neighbours");
-        String expectedMessage = String.format(MESSAGE_TASKS_LISTED_OVERVIEW, 2);
+        String expectedMessage = String.format(MESSAGE_TASKS_LISTED_OVERVIEW, 1);
         TaskNameContainsKeywordsPredicate namePredicate = prepareNamePredicate(nameList);
         TaskTagContainsKeywordsPredicate tagPredicate = prepareTagPredicate(tagList);
         FindTaskCommand command = new FindTaskCommand(namePredicate, tagPredicate);
         expectedModel.updateFilteredTaskList(namePredicate.or(tagPredicate));
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(FIRST_TASK, THIRD_TASK), model.getFilteredTaskList());
+        assertEquals(Arrays.asList(FIRST_TASK), model.getFilteredTaskList());
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/ListTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListTaskCommandTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showTaskAtIndex;
+import static seedu.address.logic.commands.CommandTestUtil.showTaskAtName;
 import static seedu.address.testutil.TypicalIndexes.TASK_SECOND_INDEX;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalTasks.getTypicalTaskBook;
@@ -35,7 +35,7 @@ public class ListTaskCommandTest {
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
-        showTaskAtIndex(model, TASK_SECOND_INDEX);
+        showTaskAtName(model, TASK_SECOND_INDEX);
         assertCommandSuccess(new ListTaskCommand(), model, ListTaskCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddTagToTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddTagToTaskCommandParserTest.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.AddTagCommand;
+import seedu.address.logic.commands.AddTagToTaskCommand;
+
+class AddTagToTaskCommandParserTest {
+
+    private static final String TAG1 = "TAG1";
+    private AddTagToTaskCommandParser parser = new AddTagToTaskCommandParser();
+
+
+    @Test
+    void parse_validArgs_returnsAddTagToTaskCommand() {
+        AddTagToTaskCommand expectedAddTagToTaskCommand = new AddTagToTaskCommand(INDEX_FIRST_PERSON, TAG1);
+        assertParseSuccess(parser, " 1 TAG1", expectedAddTagToTaskCommand);
+    }
+
+    @Test
+    void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser,
+                " 1 t/important", // Tags can only be alphanumeric
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTagToTaskCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddTagToTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddTagToTaskCommandParserTest.java
@@ -7,7 +7,6 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.AddTagCommand;
 import seedu.address.logic.commands.AddTagToTaskCommand;
 
 class AddTagToTaskCommandParserTest {

--- a/src/test/java/seedu/address/testutil/TypicalTasks.java
+++ b/src/test/java/seedu/address/testutil/TypicalTasks.java
@@ -31,7 +31,7 @@ public class TypicalTasks {
     public static final Task SECOND_TASK = new TaskBuilder().withName("Training").withDate("29-02-2020")
             .withStartTime("14:00").withEndTime("16:00")
             .withTags("colleagues").withPersons(CARL.getName().fullName).build();
-    public static final Task THIRD_TASK = new TaskBuilder().withName("Shareholder Meeting").withDate("29-02-2020")
+    public static final Task THIRD_TASK = new TaskBuilder().withName("Shareholder Conference").withDate("29-02-2020")
             .withStartTime("14:00").withEndTime("16:00")
             .withTags("colleagues").withPersons(BENSON.getName().fullName).build();
 


### PR DESCRIPTION
1. Related to #108 
2. Users may now add tags to tasks

Example:
`tag-add-t 1 important`
adds the tag "important" to the first task in the task list.

3. All tests have been implemented.