### PR TITLE
Error Message not shown in Find Person and Find Task Command

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -38,12 +38,12 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         // checks if names are valid
         for (String name: nameKeywords) {
-            ParserUtil.parseName(name);
+            ParserUtil.parseNameKeyword(name);
         }
 
         // check if tags are valid
         for (String tag: tagKeywords) {
-            ParserUtil.parseTag(tag);
+            ParserUtil.parseTagKeyword(tag);
         }
 
         return new FindCommand(new PersonNameContainsKeywordsPredicate(nameKeywords),

--- a/src/main/java/seedu/address/logic/parser/FindTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindTaskCommandParser.java
@@ -38,12 +38,12 @@ public class FindTaskCommandParser implements Parser<FindTaskCommand> {
 
         // checks if names are valid
         for (String name: nameKeywords) {
-            ParserUtil.parseName(name);
+            ParserUtil.parseNameKeyword(name);
         }
 
         // check if tags are valid
         for (String tag: tagKeywords) {
-            ParserUtil.parseTag(tag);
+            ParserUtil.parseTagKeyword(tag);
         }
 
         return new FindTaskCommand(new TaskNameContainsKeywordsPredicate(nameKeywords),

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -37,7 +37,7 @@ public class ParserUtil {
 
     public static final String MESSAGE_DIRECTORY_NOT_EXIST = "The " + Image.FILE_PATH + " directory does not exist!";
 
-
+    public static final String MESSAGE_INVALID_KEYWORD = "Keywords should be alphanumeric and should not be blank.";
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
@@ -96,6 +96,21 @@ public class ParserUtil {
         String trimmedName = name.trim();
         if (!Name.isValidName(trimmedName)) {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
+        }
+        return new Name(trimmedName);
+    }
+
+    /**
+     * Parses a {@code String nameKeyword} into a {@code Name}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code nameKeyword} is invalid or contain spaces.
+     */
+    public static Name parseNameKeyword(String nameKeyword) throws ParseException {
+        requireNonNull(nameKeyword);
+        String trimmedName = nameKeyword.trim();
+        if (!Name.isValidName(trimmedName) || trimmedName.split("\\s+").length != 1) {
+            throw new ParseException(MESSAGE_INVALID_KEYWORD);
         }
         return new Name(trimmedName);
     }
@@ -216,6 +231,21 @@ public class ParserUtil {
         String trimmedTag = tag.trim();
         if (!Tag.isValidTagName(trimmedTag)) {
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
+        }
+        return new Tag(trimmedTag);
+    }
+
+    /**
+     * Parses a {@code String tagKeyword} into a {@code Tag}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code tagKeyword} is invalid.
+     */
+    public static Tag parseTagKeyword(String tagKeyword) throws ParseException {
+        requireNonNull(tagKeyword);
+        String trimmedTag = tagKeyword.trim();
+        if (!Tag.isValidTagName(trimmedTag) || trimmedTag.split("\\s+").length != 1) {
+            throw new ParseException(MESSAGE_INVALID_KEYWORD);
         }
         return new Tag(trimmedTag);
     }


### PR DESCRIPTION
1. PR related to #217 
2. Inputs such as `find-p n/` and `find-t n/` displays the error message for the name class which tells the user that spaces are allowed. However, the intended behaviour is that keywords should not have spaces.
3. `find-p n/sabkd snal` and `find-t n/sabkd snal` does not generate any error message 