### PR TITLE
Add and Edit Task bug fixes

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
@@ -67,7 +67,7 @@ public class AddTaskCommand extends Command {
         List<Task> unfilteredTaskList = model.getUnfilteredTaskList();
         Set<Name> persons = toAdd.getPersons();
 
-        if(toAdd.hasStartEndDateConflict()){
+        if (toAdd.hasStartEndDateConflict()) {
             throw new CommandException(String.format(MESSAGE_SCHEDULE_CONFLICT_STARTEND_TIME));
         }
 

--- a/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
@@ -48,6 +48,8 @@ public class AddTaskCommand extends Command {
             "The person %1$s cannot be found in the current address book";
     public static final String MESSAGE_SCHEDULE_CONFLICT =
             "The person %1$s is already involved in a task at this date and time";
+    public static final String MESSAGE_SCHEDULE_CONFLICT_STARTEND_TIME =
+            "This task ends before or at its specified start time!";
     private final Task toAdd;
 
     /**
@@ -64,6 +66,10 @@ public class AddTaskCommand extends Command {
         List<Person> unfilteredPersonList = model.getUnfilteredPersonList();
         List<Task> unfilteredTaskList = model.getUnfilteredTaskList();
         Set<Name> persons = toAdd.getPersons();
+
+        if(toAdd.hasStartEndDateConflict()){
+            throw new CommandException(String.format(MESSAGE_SCHEDULE_CONFLICT_STARTEND_TIME));
+        }
 
         //checks if persons exist in the current list
         for (Name name: persons) {

--- a/src/main/java/seedu/address/logic/commands/EditTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditTaskCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.commands.AddTaskCommand.MESSAGE_SCHEDULE_CONFLICT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ENDTIME;
@@ -72,6 +73,7 @@ public class EditTaskCommand extends Command {
         requireNonNull(model);
         List<Task> lastShownList = model.getFilteredTaskList();
         List<Person> unfilteredPersonList = model.getUnfilteredPersonList();
+        List<Task> unfilteredTaskList = model.getUnfilteredTaskList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
@@ -86,6 +88,7 @@ public class EditTaskCommand extends Command {
 
         Set<Name> persons = editedTask.getPersons();
 
+        //person exists in contact list
         for (Name name: persons) {
             boolean notFound = true;
             for (Person person: unfilteredPersonList) {
@@ -95,6 +98,19 @@ public class EditTaskCommand extends Command {
             }
             if (notFound) {
                 throw new CommandException(String.format(MESSAGE_CONTACT_NOT_FOUND_IN_LIST, name));
+            }
+        }
+
+        //checks if persons are already involved in tasks with conflicting time ranges to the newly added task
+        for (Name name: persons) {
+            for (Task task: unfilteredTaskList) {
+                Set<Name> nameList = task.getPersons();
+                if (nameList.contains(name)) {
+                    boolean conflictExist = task.hasDateTimeConflict(editedTask);
+                    if (conflictExist) {
+                        throw new CommandException(String.format(MESSAGE_SCHEDULE_CONFLICT, name));
+                    }
+                }
             }
         }
 

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -100,6 +100,12 @@ public class Task implements Comparable<Task> {
                 && otherTask.getName().equals(getName());
     }
 
+    public boolean hasStartEndDateConflict() {
+        LocalTime thisTaskStart = LocalTime.parse(startTime.value);
+        LocalTime thisTaskEnd = LocalTime.parse(endTime.value);
+        return thisTaskEnd.compareTo(thisTaskStart) <= 0;
+    }
+
     /**
      * Returns true if both tasks have the same date and conflicting time ranges.
      */

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -100,6 +100,9 @@ public class Task implements Comparable<Task> {
                 && otherTask.getName().equals(getName());
     }
 
+    /**
+     * Returns true if task has an end time equal to or before its start time.
+     */
     public boolean hasStartEndDateConflict() {
         LocalTime thisTaskStart = LocalTime.parse(startTime.value);
         LocalTime thisTaskEnd = LocalTime.parse(endTime.value);


### PR DESCRIPTION
1. PR rectifies bug that enables users to create a task that has an endtime before the task start time #158 
2. Modifies the edit command to not allow persons to be added to tasks if they are currently assigned to another task occurring at the same time 
3. Testcases need to be checked T~T